### PR TITLE
画面遷移の修正と削除確認モーダルの実装

### DIFF
--- a/src/functions/LogoLoad.ts
+++ b/src/functions/LogoLoad.ts
@@ -1,7 +1,0 @@
-export const logo_url = "./img/logo.png";
-
-export const logoLoad = (): HTMLImageElement => {
-  const img = new Image();
-  img.src = logo_url;
-  return img;
-};

--- a/src/render/CommentDelete.tsx
+++ b/src/render/CommentDelete.tsx
@@ -1,13 +1,13 @@
-import React, {useState, useEffect, useContext} from "react";
-import {MusicLoading} from './MusicShow'
-import { useTitleDelete } from "../functions/DeleteTitle";
+import React, {useEffect, useState} from "react";
+import { BsFillTrashFill } from "react-icons/bs";
+import { useCommentDelete } from "../functions/DeleteComment";
 import ConfirmAction, { ConfirmActionInfo, defaultConfirmAction } from "./ConfirmAction";
 
-const TitleDelete: React.FC<{titleId: number}> = ({titleId}) => {
-  const [deleteResponse, titleDelete] = useTitleDelete();
-  const [actionConfirm, setConfirmAction] = useState<ConfirmActionInfo>(defaultConfirmAction)
-  const setMusicLoading = useContext(MusicLoading);
-  const confirmMessage: string = "タイトルを削除"
+
+const CommentDelete: React.FC<{commentId: number, removeCommentItem: (commentId: number)=>void}> = ({commentId, removeCommentItem}) => {
+  const [deleteResponse, commentDelete] = useCommentDelete();
+  const [actionConfirm, setConfirmAction] = useState(defaultConfirmAction);
+  const confirmMessage: string = "コメントを削除";
   
   const handleClickDelete = () => {
     const confirmShowData: ConfirmActionInfo = {
@@ -19,13 +19,13 @@ const TitleDelete: React.FC<{titleId: number}> = ({titleId}) => {
 
   useEffect(() => {
     if(actionConfirm.response){
-    titleDelete(titleId);
+      commentDelete(commentId);
     }
   }, [actionConfirm]);
 
   useEffect(() => {
     if(deleteResponse.valid){
-      setMusicLoading(true);
+      removeCommentItem(commentId);
     }else{
       if(deleteResponse.id > 0){
         alert("削除できませんでした");
@@ -34,13 +34,13 @@ const TitleDelete: React.FC<{titleId: number}> = ({titleId}) => {
   }, [deleteResponse]);
 
   return(
-    <div>
+    <div className="mx-4">
       <button onClick={handleClickDelete}>
-        タイトルを削除する
+        <BsFillTrashFill size={20} className="hover:text-yellow-400"/>
       </button>
       {actionConfirm.modalShow && <ConfirmAction setConfirmAction={setConfirmAction} message={confirmMessage} />}
     </div>
   );
 };
 
-export default TitleDelete
+export default CommentDelete

--- a/src/render/CommentList.tsx
+++ b/src/render/CommentList.tsx
@@ -1,34 +1,7 @@
-import React, {useEffect} from "react";
+import React from "react";
 import { Link } from "react-router-dom";
-import { BsFillTrashFill } from "react-icons/bs";
 import { CommentInfo } from "../functions/IndexComment";
-import { useCommentDelete } from "../functions/DeleteComment";
-
-
-const CommentDelete: React.FC<{commentId: number, removeCommentItem: (commentId: number)=>void}> = ({commentId, removeCommentItem}) => {
-  const [deleteResponse, commentDelete] = useCommentDelete();
-  
-  const handleClickDelete = () => {
-    commentDelete(commentId);
-  };
-
-  useEffect(() => {
-    if(deleteResponse.valid){
-      alert("コメントを削除しました");
-      removeCommentItem(commentId);
-    }else{
-      if(deleteResponse.id > 0){
-        alert("削除できませんでした");
-      }
-    }
-  }, [deleteResponse]);
-
-  return(
-    <button onClick={handleClickDelete} className="mx-4">
-      <BsFillTrashFill size={20} className="hover:text-yellow-400"/>
-    </button>
-  );
-};
+import CommentDelete from "./CommentDelete";
 
 const CommentList: React.FC<{commentItems: CommentInfo[], currentUserId: number, removeCommentItem: (commentId: number) => void}> = ({commentItems, currentUserId, removeCommentItem})=> {
 
@@ -36,7 +9,7 @@ const CommentList: React.FC<{commentItems: CommentInfo[], currentUserId: number,
     <ul className="overflow-auto p-4 h-72">
       {
         commentItems.map((commentItem) =>
-          <li key={commentItem.id} className="flex justify-between bg-gray-800 px-2 py-1 mb-2 w-72 rounded-md shadow-bright text-gray-100">
+          <li key={commentItem.id} className="flex justify-between items-center bg-gray-800 px-2 py-1 mb-2 w-72 rounded-md shadow-bright text-gray-100">
             <div className="flex flex-col items-start">
               <div className="flex justify-start items-center ml-2 pr-2 hover:text-yellow-400">
                 <div style={{backgroundColor: commentItem.icon_color}} className = "w-3 h-3 mr-2 rounded-full shadow-bright"></div>

--- a/src/render/ConfirmAction.tsx
+++ b/src/render/ConfirmAction.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useRef } from "react";
+import ReactDOM from 'react-dom'
+
+export type ConfirmActionInfo = {
+  modalShow: boolean
+  response: boolean
+};
+
+export const defaultConfirmAction: ConfirmActionInfo = {
+  modalShow: false,
+  response: false
+};
+
+const ConfirmAction: React.FC<{message: string, setConfirmAction:(value: ConfirmActionInfo)=>void}> = ({message, setConfirmAction}) => {
+
+  const handleSubmit = () => {
+    const confirmActionData: ConfirmActionInfo = {
+      modalShow: false,
+      response: true
+    };
+    setConfirmAction(confirmActionData);
+  };
+
+  const handleDenied = () => {
+    setConfirmAction({...defaultConfirmAction});
+  };
+
+  return ReactDOM.createPortal(
+    <div className="bg-gray-900 bg-opacity-80 flex justify-center items-center w-screen h-screen">
+      <div className="w-96 p-8 rounded-md bg-gray-600 text-yellow-400">
+        <div className="w-full mb-8" >
+          <p className="text-lg text-center">{message}してもよろしいですか？</p>
+        </div>
+        <div className="w-full flex justify-around items-center">
+          <button onClick={handleDenied} className="px-5 py-2 bg-gray-900 rounded-md shadow-bright hover:shadow-gold">
+            キャンセル
+          </button>
+          <button onClick={handleSubmit} className="px-5 py-2 bg-gray-900 rounded-md shadow-bright hover:shadow-gold">
+            確認
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.getElementById('confirmAction') as HTMLElement
+  );
+};
+
+export default ConfirmAction

--- a/src/render/Header.tsx
+++ b/src/render/Header.tsx
@@ -2,7 +2,6 @@ import React, { useContext } from 'react';
 import { CurrentUser, UserInfo } from '../functions/UserInfo';
 import { Link } from 'react-router-dom'
 import UserMenuDrop from './UserMenuDrop'
-import { logo_url } from '../functions/LogoLoad';
 
 const SignOutMenu: React.FC = () => {
   return(
@@ -27,7 +26,7 @@ const Header: React.FC = () => {
 	return (
     <header className="z-50 h-20 sticky top-0 flex justify-between items-center backdrop-filter backdrop-blur-lg backdrop-contrast-75 shadow-header">
       <Link to="/">
-        <img src={logo_url} alt="AstResonance" className="h-16 m-2"></img>
+        <img src={"./img/logo.png"} alt="AstResonance" className="h-16 m-2"></img>
       </Link>
       { userInfo.isSignIn ? <SignInMenu userInfo={userInfo}/> : <SignOutMenu />}
     </header>

--- a/src/render/Main.tsx
+++ b/src/render/Main.tsx
@@ -42,6 +42,7 @@ const Main: React.FC = () => {
         </CurrentUser.Provider>
       </div>
       <Background />
+      <div id="confirmAction" className="absolute z-50"></div>
     </div>
 	);
 }

--- a/src/render/Main.tsx
+++ b/src/render/Main.tsx
@@ -11,13 +11,11 @@ import UserShow from './UserShow';
 import { useEffect } from 'react';
 import Background from './Background';
 import { CurrentUser, useUserContext } from '../functions/UserInfo';
-import { logoLoad } from '../functions/LogoLoad';
 
 
 const Main: React.FC = () => {
   const {userInfo, setUserInfo} = useUserContext();
-  const img = logoLoad();
-
+  
   useEffect(() => {
     setUserInfo.validateToken();
   },[]);

--- a/src/render/MusicEdit.tsx
+++ b/src/render/MusicEdit.tsx
@@ -5,10 +5,13 @@ import { useMusicEdit } from "../functions/EditMusic";
 import { selectIds } from "./Home";
 import { MusicInfo } from "../functions/IndexMusic";
 import { genreItems, categoryItems } from "../functions/MusicGenre";
+import { useContext } from "react";
+import { MusicLoading } from "./MusicShow";
 
 const MusicEdit: React.FC<{musicItem: MusicInfo, setEditShow: (setShow: boolean)=>void}> = ({musicItem, setEditShow}) => {
   const [editResponse, musicEdit] = useMusicEdit();
   const { register, handleSubmit, watch, formState: {errors} } = useForm();
+  const setMusicLoading = useContext(MusicLoading);
   const popUpRef: any = useRef();
   const formRef: any = useRef();
   
@@ -26,7 +29,7 @@ const MusicEdit: React.FC<{musicItem: MusicInfo, setEditShow: (setShow: boolean)
   useEffect(() => {
     if(editResponse.valid){
       alert("音楽情報を変更しました");
-      window.location.reload();
+      setMusicLoading(true);
     }else{
       if(editResponse.id > 0){
         alert("変更できませんでした");

--- a/src/render/MusicShow.tsx
+++ b/src/render/MusicShow.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect, useContext, useRef} from "react";
+import React, {useState, useEffect, useContext} from "react";
 import { useParams } from "react-router-dom";
 import { CurrentUser } from "../functions/UserInfo";
 import TitleShow from './TitleShow';
@@ -19,16 +19,27 @@ export const defaultShow: CurrentShow = {
   showId: -1
 };
 
+export const MusicLoading = React.createContext({} as React.Dispatch<React.SetStateAction<boolean>>);
+
 const MusicShow: React.FC = () => {
   const [{musicItem, titleItems, userTitle, response}, musicShow] = useMusicShow();
   const [ currentTitleShow, setTitleShow ] = useState<CurrentShow>(defaultShow);
   const [ musicEditShow, setEditShow ] = useState<boolean>(false);
   const { userInfo, setUserInfo} = useContext(CurrentUser);
   const {id: currentMusicId, title_id: initialTitleId} = useParams<{id: string, title_id: string}>();
+  const [ loadingFlag, setMusicLoading ] = useState<boolean>(true);
   
   useEffect(()=>{
-    musicShow(currentMusicId);
+    setMusicLoading(true);
   },[currentMusicId]);
+
+  useEffect(()=>{
+    console.log("loading");
+    if(loadingFlag==true){
+      console.log("init");
+      musicShow(currentMusicId);
+    }
+  },[loadingFlag]);
 
   useEffect(()=>{
     if(initialTitleId && userInfo.isSignIn && (userTitle.isTitled || userInfo.id == musicItem.user_id)){
@@ -37,17 +48,22 @@ const MusicShow: React.FC = () => {
         showId: Number(initialTitleId),
       };
       setTitleShow(setCurrent);
+    }else{
+      setTitleShow(defaultShow);
+      setEditShow(false);
     }
+    setMusicLoading(false);
   },[response]);
   
   return (
     <div>
+    <MusicLoading.Provider value={setMusicLoading}>
       <div className="flex justify-center h-home">
         <div className= "flex flex-col justify-between items-center my-2">
           <div className="w-96 mx-8 my-6 rounded-md text-gray-100 px-4 pt-2 pb-3 shadow-bright backdrop-filter backdrop-blur-lg">
             { (!response.valid && response.errors.errors)? <p className="text-red-600"></p> :
               userInfo.isSignIn? ( musicItem.user_id == userInfo.id? <YourPostedMusic musicId={musicItem.id} setEditShow={setEditShow} /> :
-                ( userTitle.isTitled? <MusicTitled userTitle = {userTitle.titleData}/> : <MakeTitleForSignedIn currentMusicId={currentMusicId}/>)) : <RejectTitleForSignOut />}
+                ( userTitle.isTitled? <MusicTitled userTitle = {userTitle.titleData}/> : <MakeTitleForSignedIn currentMusicId={currentMusicId} />)) : <RejectTitleForSignOut />}
           </div>
           <div className="my-4">
             <ReactAudioPlayer controls src={musicItem.music_url} autoPlay={true} volume={0.5} controlsList="nodownload" />
@@ -67,6 +83,7 @@ const MusicShow: React.FC = () => {
       </div>
       <MusicFooter musicItem={musicItem} userInfo={userInfo} userTitle={userTitle} />
       { musicEditShow && <MusicEdit musicItem={musicItem} setEditShow={setEditShow} />}
+    </MusicLoading.Provider>
     </div>
   );
 };

--- a/src/render/MusicShowForm.tsx
+++ b/src/render/MusicShowForm.tsx
@@ -4,6 +4,8 @@ import { useForm } from "react-hook-form";
 import { TitleInfo } from "../functions/ShowTitle"
 import { useTitleCreate } from "../functions/CreateTitle";
 import { useMusicDelete } from "../functions/DeleteMusic";
+import { useContext } from "react";
+import { MusicLoading } from "./MusicShow";
 
 export type TitleInput = {
   title: string
@@ -22,6 +24,7 @@ export const MusicTitled: React.FC<{userTitle: TitleInfo}> = ({userTitle}) => {
 export const MakeTitleForSignedIn: React.FC<{currentMusicId: string}> = ({currentMusicId}) => {
   const [responseState, titleCreate] = useTitleCreate();
   const { register, handleSubmit, watch, formState: {errors} } = useForm();
+  const setMusicLoading = useContext(MusicLoading);
 
   const onSubmit = (data: TitleInput) => {
         titleCreate(currentMusicId, data);
@@ -29,7 +32,7 @@ export const MakeTitleForSignedIn: React.FC<{currentMusicId: string}> = ({curren
 
   useEffect(() => {
     if(responseState.valid){
-      window.location.reload();
+      setMusicLoading(true);
     }
   }, [responseState])
 

--- a/src/render/MusicShowForm.tsx
+++ b/src/render/MusicShowForm.tsx
@@ -6,6 +6,7 @@ import { useTitleCreate } from "../functions/CreateTitle";
 import { useMusicDelete } from "../functions/DeleteMusic";
 import { useContext } from "react";
 import { MusicLoading } from "./MusicShow";
+import ConfirmAction, { ConfirmActionInfo, defaultConfirmAction } from "./ConfirmAction";
 
 export type TitleInput = {
   title: string
@@ -70,18 +71,29 @@ export const RejectTitleForSignOut: React.FC = () => {
 export const YourPostedMusic: React.FC<{musicId: number, setEditShow: (setShow: boolean)=>void}> = ({musicId, setEditShow}) => {
   const history = useHistory();
   const [deleteResponse, musicDelete] = useMusicDelete();
+  const [actionConfirm, setConfirmAction] = useState(defaultConfirmAction);
+  const confirmMessage = "音楽を削除";
   
   const handleClickDelete = () => {
-    musicDelete(musicId);
+    const confirmShowData: ConfirmActionInfo = {
+      modalShow: true,
+      response: false
+    };
+    setConfirmAction(confirmShowData);
   };
 
   const handleClickEdit = () => {
     setEditShow(true);
   };
+  
+  useEffect(() => {
+    if(actionConfirm.response){
+      musicDelete(musicId);
+    }
+  }, [actionConfirm]);
 
   useEffect(() => {
     if(deleteResponse.valid){
-      alert("音楽を削除しました");
       history.push('/');
     }else{
       if(deleteResponse.id > 0){
@@ -97,6 +109,7 @@ export const YourPostedMusic: React.FC<{musicId: number, setEditShow: (setShow: 
         <button onClick={handleClickEdit} className="border-b hover:text-yellow-300">音楽情報を編集する</button>
         <button onClick={handleClickDelete} className="border-b hover:text-yellow-300">音楽を削除する</button>
       </div>
+      {actionConfirm.modalShow && <ConfirmAction setConfirmAction={setConfirmAction} message={confirmMessage} />}
     </div>
   );
 };

--- a/src/render/TitleDelete.tsx
+++ b/src/render/TitleDelete.tsx
@@ -1,0 +1,47 @@
+import React, {useState, useEffect, useContext} from "react";
+import {MusicLoading} from './MusicShow'
+import { useTitleDelete } from "../functions/DeleteTitle";
+import ConfirmAction, { ConfirmActionInfo, defaultConfirmAction } from "./ConfirmAction";
+
+const TitleDelete: React.FC<{titleId: number}> = ({titleId}) => {
+  const [deleteResponse, titleDelete] = useTitleDelete();
+  const [actionConfirm, setConfirmAction] = useState<ConfirmActionInfo>(defaultConfirmAction)
+  const setMusicLoading = useContext(MusicLoading);
+  const confirmMessage: string = "タイトルを削除"
+  
+  const handleClickDelete = () => {
+    const confirmShowData: ConfirmActionInfo = {
+      modalShow: true,
+      response: false
+    };
+    setConfirmAction(confirmShowData);
+  };
+
+  useEffect(() => {
+    if(actionConfirm.response){
+    titleDelete(titleId);
+    }
+  }, [actionConfirm]);
+
+  useEffect(() => {
+    if(deleteResponse.valid){
+      alert("タイトルを削除しました");
+      setMusicLoading(true);
+    }else{
+      if(deleteResponse.id > 0){
+        alert("削除できませんでした");
+      }
+    }
+  }, [deleteResponse]);
+
+  return(
+    <div>
+      <button onClick={handleClickDelete}>
+        タイトルを削除する
+      </button>
+      {actionConfirm.modalShow && <ConfirmAction setConfirmAction={setConfirmAction} message={confirmMessage} />}
+    </div>
+  );
+};
+
+export default TitleDelete

--- a/src/render/TitleShow.tsx
+++ b/src/render/TitleShow.tsx
@@ -1,39 +1,13 @@
-import React, {useEffect, useState, useContext} from "react";
+import React, {useEffect, useContext} from "react";
 import { Link } from "react-router-dom";
-import {CurrentShow, defaultShow, MusicLoading} from './MusicShow'
+import {CurrentShow, defaultShow} from './MusicShow'
 import { CurrentUser } from "../functions/UserInfo";
 import {AiOutlineArrowRight} from 'react-icons/ai'
-import { useTitleDelete } from "../functions/DeleteTitle";
 import { useTitleShow } from "../functions/ShowTitle";
 import { useCommentIndex } from "../functions/IndexComment";
 import CommentList from "./CommentList";
 import CommentCreate from "./CommentCreate";
-
-const TitleDelete: React.FC<{titleId: number}> = ({titleId}) => {
-  const [deleteResponse, titleDelete] = useTitleDelete();
-  const setMusicLoading = useContext(MusicLoading);
-  
-  const handleClickDelete = () => {
-    titleDelete(titleId);
-  };
-
-  useEffect(() => {
-    if(deleteResponse.valid){
-      alert("タイトルを削除しました");
-      setMusicLoading(true);
-    }else{
-      if(deleteResponse.id > 0){
-        alert("削除できませんでした");
-      }
-    }
-  }, [deleteResponse]);
-
-  return(
-    <button onClick={handleClickDelete}>
-      タイトルを削除する
-    </button>
-  );
-};
+import TitleDelete from "./TitleDelete";
 
 const TitleShow: React.FC<{titleId: number, musicId: number, setTitleShow: (setShow: CurrentShow)=> void}> = ({titleId, musicId, setTitleShow}) => {
   const [{titleItem, titleResponse}, titleShow] = useTitleShow();

--- a/src/render/TitleShow.tsx
+++ b/src/render/TitleShow.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState, useContext} from "react";
 import { Link } from "react-router-dom";
-import {CurrentShow, defaultShow} from './MusicShow'
+import {CurrentShow, defaultShow, MusicLoading} from './MusicShow'
 import { CurrentUser } from "../functions/UserInfo";
 import {AiOutlineArrowRight} from 'react-icons/ai'
 import { useTitleDelete } from "../functions/DeleteTitle";
@@ -11,6 +11,7 @@ import CommentCreate from "./CommentCreate";
 
 const TitleDelete: React.FC<{titleId: number}> = ({titleId}) => {
   const [deleteResponse, titleDelete] = useTitleDelete();
+  const setMusicLoading = useContext(MusicLoading);
   
   const handleClickDelete = () => {
     titleDelete(titleId);
@@ -19,7 +20,7 @@ const TitleDelete: React.FC<{titleId: number}> = ({titleId}) => {
   useEffect(() => {
     if(deleteResponse.valid){
       alert("タイトルを削除しました");
-      window.location.reload();
+      setMusicLoading(true);
     }else{
       if(deleteResponse.id > 0){
         alert("削除できませんでした");


### PR DESCRIPTION
# What
画面遷移の際にウィンドウリロードを使わないように修正した。また、投稿の削除際には確認モーダルが表示されるようにした。
# Why
タイトルを決定した際に音楽が途切れたり、ロゴが消えたりしないようにするため。また、誤操作防止のため。